### PR TITLE
fixed kanboard environment for development.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,33 @@
-version: '2'
+version: '3'
 services:
   kanboard:
-    image: kanboard/kanboard:latest
+    build:
+      context: ./
+      dockerfile: Dockerfile
     ports:
      - "80:80"
      - "443:443"
     volumes:
+     - .:/var/www/app:cached
      - kanboard_data:/var/www/app/data
      - kanboard_plugins:/var/www/app/plugins
      - kanboard_ssl:/etc/nginx/ssl
+    environment:
+      DATABASE_URL: mysql://kb:kb-secret@db/kanboard
+
+  db:
+    image: mariadb:latest
+    expose:
+      - "3306"
+    ports:
+      - "127.0.0.1:3306:3306"
+    command: --default-authentication-plugin=mysql_native_password
+    environment:
+      MYSQL_ROOT_PASSWORD: secret
+      MYSQL_DATABASE: kanboard
+      MYSQL_USER: kb
+      MYSQL_PASSWORD: kb-secret
+
 volumes:
   kanboard_data:
     driver: local

--- a/docker/etc/php7/conf.d/local.ini
+++ b/docker/etc/php7/conf.d/local.ini
@@ -7,6 +7,7 @@ date.timezone = UTC
 allow_url_fopen = On
 post_max_size = 32M
 upload_max_filesize = 32M
+opcache.enable = Off
 opcache.max_accelerated_files = 7963
 opcache.validate_timestamps = Off
 opcache.save_comments = 0


### PR DESCRIPTION
## Overview

kanboardのローカル環境での開発のために、Dockerの設定を更新しました。

```yml
  db:
    image: mariadb:latest
    expose:
      - "3306"
    ports:
      - "127.0.0.1:3306:3306"
    command: --default-authentication-plugin=mysql_native_password
    environment:
      MYSQL_ROOT_PASSWORD: secret
      MYSQL_DATABASE: kanboard
      MYSQL_USER: kb
      MYSQL_PASSWORD: kb-secret
```

とあるようにMySQLクライアントツールからのアクセスも可能にしています 💁 
詳細はTeamsに書いておきます✍

次にPHPファイルが更新されていない原因ですが、OPCacheが有効になっていてphp-fpmが一度起動したらPHPファイルをキャッシュするようになっています。
これをOffにすることで編集時に更新されるようにしました。

